### PR TITLE
Criação de dois endpoints simples e integração com o interceptor de g…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<dependency>
 			<groupId>br.les.opus</groupId>
 			<artifactId>zika-core</artifactId>
-			<version>0.2.0</version>
+			<version>0.3.0</version>
 		</dependency>
 
 		<!-- Spring dependencies -->
@@ -311,7 +311,7 @@
 				<artifactId>maven-war-plugin</artifactId>
 				<version>2.6</version>
 				<configuration>
-					<warName>dengue-api-desenv</warName>
+					<warName>zika-api</warName>
 					<webXml>src/main/webapp/WEB-INF/web.xml</webXml>
 				</configuration>
 			</plugin>

--- a/src/main/java/br/les/opus/dengue/gamification/controllers/BadgeController.java
+++ b/src/main/java/br/les/opus/dengue/gamification/controllers/BadgeController.java
@@ -1,0 +1,26 @@
+package br.les.opus.dengue.gamification.controllers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import br.les.opus.commons.persistence.PagingSortingFilteringRepository;
+import br.les.opus.commons.rest.controllers.ReadOnlyController;
+import br.les.opus.gamification.domain.Badge;
+import br.les.opus.gamification.repositories.BadgeRepository;
+
+@RestController
+@Transactional
+@RequestMapping("/game/badge")
+public class BadgeController extends ReadOnlyController<Badge> {
+	
+	@Autowired
+	private BadgeRepository repository;
+
+	@Override
+	protected PagingSortingFilteringRepository<Badge, Long> getRepository() {
+		return repository;
+	}
+
+}

--- a/src/main/java/br/les/opus/dengue/gamification/controllers/PlayerController.java
+++ b/src/main/java/br/les/opus/dengue/gamification/controllers/PlayerController.java
@@ -1,0 +1,38 @@
+package br.les.opus.dengue.gamification.controllers;
+
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import br.les.opus.gamification.domain.Badge;
+import br.les.opus.gamification.domain.Player;
+import br.les.opus.gamification.repositories.BadgeRepository;
+import br.les.opus.gamification.services.GamificationService;
+
+@RestController
+@Transactional
+@RequestMapping("/game/player")
+public class PlayerController {
+	
+	@Autowired
+	private BadgeRepository badgeDao;
+	
+	@Autowired
+	private GamificationService gameService;
+
+	@RequestMapping(value="badges", method = RequestMethod.GET) 
+	public ResponseEntity< List<Badge> > findAllBadgesAndProgressions(HttpServletRequest request) {
+		Player player = gameService.loadPlayer(request);
+		
+		List<Badge> badges = badgeDao.findAllWithProgressions(player);
+		return new ResponseEntity<>(badges, HttpStatus.OK);
+	}
+}

--- a/src/main/resources/app-config.xml
+++ b/src/main/resources/app-config.xml
@@ -28,9 +28,9 @@
             <mvc:mapping path="/**" />
             <bean class="br.les.opus.auth.core.interceptors.AuthHandlerInterceptor"/>
         </mvc:interceptor>
-         <mvc:interceptor>
+        <mvc:interceptor>
             <mvc:mapping path="/**" />
-            <bean class="br.les.opus.gamification.interceptors.GamificationLoggerInterceptor"/>
+            <bean class="br.les.opus.gamification.interceptors.GamificationInterceptor"/>
         </mvc:interceptor>
     </mvc:interceptors>
 

--- a/src/main/resources/hibernate-config.xml
+++ b/src/main/resources/hibernate-config.xml
@@ -32,7 +32,7 @@
             <props> 
                 <prop key="hibernate.dialect">br.les.opus.commons.persistence.dialect.AdaptedPostgisDialect</prop> 
                 <prop key="hibernate.show_sql">true</prop>
-                <prop key="hibernate.max_fetch_depth">3</prop>
+                <!-- <prop key="hibernate.max_fetch_depth">3</prop> -->
                 <prop key="hibernate.format_sql">true</prop>
                 <prop key="javax.persistence.validation.mode">none</prop>
 				<prop key="hibernate.hbm2ddl.auto">update</prop>
@@ -49,6 +49,18 @@
 		<property name="jdbcUrl" value="jdbc:postgresql://localhost/dengue" />
 		<property name="user" value="diego" />
 		<property name="password" value="" />
+	    <property name="minPoolSize" value="1" />
+	    <property name="maxPoolSize" value="20" />
+	    <property name="acquireIncrement" value="1" />
+	    <property name="idleConnectionTestPeriod" value="180" />
+	    <property name="maxIdleTime" value="200" />
+	</bean> 
+	
+	<bean id="dataSourceDocker" class="com.mchange.v2.c3p0.ComboPooledDataSource" destroy-method="close"> 
+		<property name="driverClass" value="org.postgresql.Driver" />
+		<property name="jdbcUrl" value="jdbc:postgresql://localhost/vazazika" />
+		<property name="user" value="docker" />
+		<property name="password" value="docker" />
 	    <property name="minPoolSize" value="1" />
 	    <property name="maxPoolSize" value="20" />
 	    <property name="acquireIncrement" value="1" />


### PR DESCRIPTION
Integra a api com o interceptor de gamificação (https://github.com/vazaazika/zika-core/pull/3)

Criei dois endpoints simples pra testar:

/game/badge -> apresenta a lista de todos os badges do game
/game/player/badges -> apresenta a lista de todos os badges do game junto com o progresso do player em cada

Fiz uns testes manuais e o interceptor parece estar funcionando como o esperado (monitorando progresso nas taskgroups, xp, level...)